### PR TITLE
Fix code sniffer warnings

### DIFF
--- a/src/Deserializers/LegacyStatementDeserializer.php
+++ b/src/Deserializers/LegacyStatementDeserializer.php
@@ -63,6 +63,7 @@ class LegacyStatementDeserializer implements Deserializer {
 	}
 
 	private function newStatement() {
+		/** @var Claim $claim */
 		$claim = $this->claimDeserializer->deserialize( $this->serialization );
 
 		$statement = $this->newStatementFromClaim( $claim );

--- a/tests/integration/Deserializers/EntityDeserializerTest.php
+++ b/tests/integration/Deserializers/EntityDeserializerTest.php
@@ -64,9 +64,7 @@ class EntityDeserializerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function newTestItem() {
-		$item = Item::newEmpty();
-
-		$item->setId( new ItemId( 'Q42' ) );
+		$item = new Item( new ItemId( 'Q42' ) );
 
 		$item->setLabel( 'en', 'foo' );
 		$item->setLabel( 'de', 'bar' );

--- a/tests/integration/SerializerFactoryTest.php
+++ b/tests/integration/SerializerFactoryTest.php
@@ -23,7 +23,7 @@ class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testEntitySerializerConstruction() {
-		$this->factory->newEntitySerializer()->serialize( Item::newEmpty() );
+		$this->factory->newEntitySerializer()->serialize( new Item() );
 
 		$this->assertTrue(
 			true,


### PR DESCRIPTION
This patch fixes some smaller issues found by PHPStorm's static code analysis.
* Favor `new Item` over deprecated `newEmpty`.
* Avoid calling `setId` if not necessary.
* Suppress warning caused by the `Deserializer` interface with an `@var` tag.