### PR TITLE
Do not store serialization during deserialization

### DIFF
--- a/src/Deserializers/EntityDeserializer.php
+++ b/src/Deserializers/EntityDeserializer.php
@@ -10,6 +10,7 @@ use Wikibase\DataModel\Entity\EntityDocument;
 /**
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
 class EntityDeserializer implements Deserializer {
 
@@ -22,11 +23,6 @@ class EntityDeserializer implements Deserializer {
 	 * @var DispatchableDeserializer
 	 */
 	private $currentDeserializer;
-
-	/**
-	 * @var mixed
-	 */
-	private $serialization;
 
 	public function __construct(
 		Deserializer $legacyDeserializer,
@@ -47,41 +43,38 @@ class EntityDeserializer implements Deserializer {
 			throw new DeserializationException( 'Entity serialization must be an array' );
 		}
 
-		$this->serialization = $serialization;
-
-		if ( $this->isLegacySerialization() ) {
-			return $this->fromLegacySerialization();
-		}
-		elseif ( $this->isCurrentSerialization() ) {
-			return $this->fromCurrentSerialization();
-		}
-		else {
-			return $this->fromUnknownSerialization();
+		if ( $this->isLegacySerialization( $serialization ) ) {
+			return $this->fromLegacySerialization( $serialization );
+		} elseif ( $this->isCurrentSerialization( $serialization ) ) {
+			return $this->fromCurrentSerialization( $serialization );
+		} else {
+			return $this->fromUnknownSerialization( $serialization );
 		}
 	}
 
-	private function isLegacySerialization() {
-		return array_key_exists( 'entity', $this->serialization );
+	private function isLegacySerialization( array $serialization ) {
+		// This element is called 'id' in the current serialization.
+		return array_key_exists( 'entity', $serialization );
 	}
 
-	private function isCurrentSerialization() {
-		return $this->currentDeserializer->isDeserializerFor( $this->serialization );
+	private function isCurrentSerialization( array $serialization ) {
+		return $this->currentDeserializer->isDeserializerFor( $serialization );
 	}
 
-	private function fromLegacySerialization() {
-		return $this->legacyDeserializer->deserialize( $this->serialization );
+	private function fromLegacySerialization( array $serialization ) {
+		return $this->legacyDeserializer->deserialize( $serialization );
 	}
 
-	private function fromCurrentSerialization() {
-		return $this->currentDeserializer->deserialize( $this->serialization );
+	private function fromCurrentSerialization( array $serialization ) {
+		return $this->currentDeserializer->deserialize( $serialization );
 	}
 
-	private function fromUnknownSerialization() {
+	private function fromUnknownSerialization( array $serialization ) {
 		try {
-			return $this->fromLegacySerialization();
+			return $this->fromLegacySerialization( $serialization );
 		} catch ( DeserializationException $legacyEx ) {
 			try {
-				return $this->fromCurrentSerialization();
+				return $this->fromCurrentSerialization( $serialization );
 			} catch ( DeserializationException $currentEx ) {
 				throw new DeserializationException(
 					'The provided entity serialization is neither legacy ('

--- a/src/Deserializers/LegacyStatementDeserializer.php
+++ b/src/Deserializers/LegacyStatementDeserializer.php
@@ -14,13 +14,19 @@ use Wikibase\DataModel\Statement\Statement;
  * @licence GNU GPL v2+
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Bene* < benestar.wikimedia@gmail.com >
  */
 class LegacyStatementDeserializer implements Deserializer {
 
+	/**
+	 * @var Deserializer
+	 */
 	private $snakDeserializer;
-	private $snakListDeserializer;
 
-	private $serialization;
+	/**
+	 * @var Deserializer
+	 */
+	private $snakListDeserializer;
 
 	public function __construct( Deserializer $snakDeserializer, Deserializer $snakListDeserializer ) {
 		$this->snakDeserializer = $snakDeserializer;
@@ -34,81 +40,50 @@ class LegacyStatementDeserializer implements Deserializer {
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {
-		$this->serialization = $serialization;
-
-		$this->assertIsArray();
-		$this->assertHasKey( 'm', 'Mainsnak serialization is missing' );
-		$this->assertHasKey( 'q', 'Qualifiers serialization is missing' );
-		$this->assertHasKey( 'g', 'Guid is missing in serialization' );
-		$this->assertHasKey( 'rank', 'Rank is missing in serialization' );
-		$this->assertHasKey( 'refs', 'Refs are missing in serialization' );
-
-		return $this->newStatement();
-	}
-
-	private function assertIsArray() {
-		if ( !is_array( $this->serialization ) ) {
-			throw new DeserializationException( 'Statement serialization should be an array' );
+		if ( !is_array( $serialization ) ) {
+			throw new DeserializationException( 'Statement serialization must be an array' );
 		}
+
+		$this->assertHasKey( $serialization, 'm', 'Mainsnak serialization is missing' );
+		$this->assertHasKey( $serialization, 'q', 'Qualifiers serialization is missing' );
+		$this->assertHasKey( $serialization, 'g', 'Guid is missing in serialization' );
+		$this->assertHasKey( $serialization, 'rank', 'Rank is missing in serialization' );
+		$this->assertHasKey( $serialization, 'refs', 'Refs are missing in serialization' );
+
+		return $this->newStatement( $serialization );
 	}
 
-	private function assertHasKey( $key, $message ) {
-		if ( !array_key_exists( $key, $this->serialization ) ) {
+	private function assertHasKey( array $serialization, $key, $message ) {
+		if ( !array_key_exists( $key, $serialization ) ) {
 			throw new MissingAttributeException( $key, $message );
 		}
 	}
 
-	private function newStatement() {
+	private function newStatement( array $serialization ) {
 		$statement = new Statement(
-			$this->getMainSnak(),
-			$this->getQualifiers(),
-			$this->getReferences()
+			$this->snakDeserializer->deserialize( $serialization['m'] ),
+			$this->snakListDeserializer->deserialize( $serialization['q'] ),
+			$this->getReferences( $serialization['refs'] )
 		);
 
-		$this->setRank( $statement );
-		$this->setGuid( $statement );
+		try {
+			$statement->setRank( $serialization['rank'] );
+			$statement->setGuid( $serialization['g'] );
+		} catch ( InvalidArgumentException $ex ) {
+			throw new DeserializationException( $ex->getMessage(), $ex );
+		}
 
 		return $statement;
 	}
 
-	private function getMainSnak() {
-		return $this->snakDeserializer->deserialize( $this->serialization['m'] );
-	}
-
-	private function getQualifiers() {
-		return $this->snakListDeserializer->deserialize( $this->serialization['q'] );
-	}
-
-	private function setRank( Statement $statement ) {
-		try {
-			$statement->setRank( $this->serialization['rank'] );
-		}
-		catch ( InvalidArgumentException $ex ) {
-			throw new DeserializationException( $ex->getMessage(), $ex );
-		}
-	}
-
-	private function setGuid( Statement $statement ) {
-		try {
-			$statement->setGuid( $this->serialization['g'] );
-		}
-		catch ( InvalidArgumentException $ex ) {
-			throw new DeserializationException( $ex->getMessage(), $ex );
-		}
-	}
-
-	private function getReferences() {
+	private function getReferences( array $refs ) {
 		$references = array();
 
-		foreach ( $this->serialization['refs'] as $referenceSerialization ) {
-			$references[] = $this->deserializeReference( $referenceSerialization );
+		foreach ( $refs as $serialization ) {
+			$references[] = new Reference( $this->snakListDeserializer->deserialize( $serialization ) );
 		}
 
 		return new ReferenceList( $references );
-	}
-
-	private function deserializeReference( $serialization ) {
-		return new Reference( $this->snakListDeserializer->deserialize( $serialization ) );
 	}
 
 }


### PR DESCRIPTION
This is a resubmission of #31.

~~[WIP] because tests for the introduced `is_array` checks are missing.~~ **Edit:** The tests are in #70.

[Bug: T98124](https://phabricator.wikimedia.org/T98124)