### PR TITLE
Name ClassLoader object $classLoader

### DIFF
--- a/src/Deserializers/LegacyPropertyDeserializer.php
+++ b/src/Deserializers/LegacyPropertyDeserializer.php
@@ -53,7 +53,6 @@ class LegacyPropertyDeserializer implements Deserializer {
 	 * @param array $serialization
 	 *
 	 * @return PropertyId|null
-	 *
 	 * @throws InvalidAttributeException
 	 */
 	private function getPropertyId( array $serialization ) {
@@ -78,7 +77,6 @@ class LegacyPropertyDeserializer implements Deserializer {
 	 * @param array $serialization
 	 *
 	 * @return string
-	 *
 	 * @throws MissingAttributeException
 	 * @throws InvalidAttributeException
 	 */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,10 +8,10 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );
 }
 
-$autoLoader = require __DIR__ . '/../vendor/autoload.php';
+$classLoader = require __DIR__ . '/../vendor/autoload.php';
 
-$autoLoader->addPsr4(
+$classLoader->addPsr4(
 	'Tests\\Integration\\Wikibase\\InternalSerialization\\', __DIR__ . '/integration/'
 );
 
-unset( $autoLoader );
+unset( $classLoader );


### PR DESCRIPTION
This fixes two minor style issues, for consistency within the Wikibase code base:
- No empty line between `@throws` and `@return`.
- The `$classLoader` variable refers to a `ClassLoader` object.

Also see:
- https://github.com/wmde/WikibaseDataModel/pull/582
- https://github.com/wmde/WikibaseDataModelServices/pull/98
