### PR TITLE
Compatible with DataValues Common 0.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.3",
 		"phpmd/phpmd": "~2.3",
-		"data-values/common": "~0.2.2",
+		"data-values/common": "~0.3.0|~0.2.0",
 		"data-values/geo": "~1.1",
 		"data-values/number": "~0.5.0",
 		"data-values/time": "~0.7.0"


### PR DESCRIPTION
* This component is compatible with Common 0.3.x. [The breaking changes between Common 0.2.x and 0.3.x](https://github.com/DataValues/Common/compare/0.2.3...0.3.0) are not used here.
* This component is also compatible with Common 0.2.0. [The additions between Common 0.2.0 and 0.2.2](https://github.com/DataValues/Common/compare/0.2...0.2.2) are not used here.

Also see:
* https://github.com/DataValues/Geo/pull/58
* https://github.com/DataValues/Number/pull/53
* https://github.com/wmde/WikibaseDataModelSerialization/pull/183