### PR TITLE
Support custom entity deserializer in DeserializerFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Wikibase Internal Serialization has been written by [Jeroen De Dauw]
 
 ## Release notes
 
+### 2.2.0 (dev)
+
+* `DeserializerFactory` constructor now optionally takes a `DispatchableDeserializer` as third argument
+
 ### 2.1.0 (2016-02-18)
 
 * Added compatibility with Wikibase DataModel 5.x

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.1.x-dev"
+			"dev-master": "2.2.x-dev"
 		}
 	},
 	"scripts": {

--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -40,6 +40,12 @@ class DeserializerFactory {
 	 */
 	private $currentEntityDeserializer;
 
+	/**
+	 * @param Deserializer $dataValueDeserializer
+	 * @param EntityIdParser $idParser
+	 * @param DispatchableDeserializer|null $currentEntityDeserializer used instead of constructing
+	 *        a new current Deserializer for entities using a current DeserializerFactory.
+	 */
 	public function __construct(
 		Deserializer $dataValueDeserializer,
 		EntityIdParser $idParser,

--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -3,6 +3,7 @@
 namespace Wikibase\InternalSerialization;
 
 use Deserializers\Deserializer;
+use Deserializers\DispatchableDeserializer;
 use Wikibase\DataModel\DeserializerFactory as CurrentDeserializerFactory;
 use Wikibase\DataModel\Entity\EntityIdParser;
 use Wikibase\InternalSerialization\Deserializers\EntityDeserializer;
@@ -34,9 +35,19 @@ class DeserializerFactory {
 	 */
 	private $currentFactory;
 
-	public function __construct( Deserializer $dataValueDeserializer, EntityIdParser $idParser ) {
+	/**
+	 * @var DispatchableDeserializer|null $currentEntityDeserializer
+	 */
+	private $currentEntityDeserializer;
+
+	public function __construct(
+		Deserializer $dataValueDeserializer,
+		EntityIdParser $idParser,
+		DispatchableDeserializer $currentEntityDeserializer = null
+	) {
 		$this->legacyFactory = new LegacyDeserializerFactory( $dataValueDeserializer, $idParser );
 		$this->currentFactory = new CurrentDeserializerFactory( $dataValueDeserializer, $idParser );
+		$this->currentEntityDeserializer = $currentEntityDeserializer;
 	}
 
 	/**
@@ -45,7 +56,7 @@ class DeserializerFactory {
 	public function newEntityDeserializer() {
 		return new EntityDeserializer(
 			$this->legacyFactory->newEntityDeserializer(),
-			$this->currentFactory->newEntityDeserializer()
+			$this->currentEntityDeserializer ?: $this->currentFactory->newEntityDeserializer()
 		);
 	}
 

--- a/tests/integration/DeserializerFactoryTest.php
+++ b/tests/integration/DeserializerFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Integration\Wikibase\InternalSerialization;
 
+use Wikibase\DataModel\Entity\BasicEntityIdParser;
 use Wikibase\InternalSerialization\DeserializerFactory;
 
 /**
@@ -9,6 +10,7 @@ use Wikibase\InternalSerialization\DeserializerFactory;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Bene* < benestar.wikimedia@gmail.com >
  */
 class DeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 
@@ -21,8 +23,24 @@ class DeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->factory = TestFactoryBuilder::newDeserializerFactory( $this );
 	}
 
-	public function testGetEntityDeserializerReturnsDeserializer() {
+	public function testNewEntityDeserializerReturnsDeserializer() {
 		$deserializer = $this->factory->newEntityDeserializer();
+		$this->assertInstanceOf( 'Deserializers\Deserializer', $deserializer );
+	}
+
+	public function testNewStatementDeserializerReturnsDeserializer() {
+		$deserializer = $this->factory->newStatementDeserializer();
+		$this->assertInstanceOf( 'Deserializers\Deserializer', $deserializer );
+	}
+
+	public function testConstructWithCustomEntityDeserializer() {
+		$factory = new DeserializerFactory(
+			$this->getMock( 'Deserializers\Deserializer' ),
+			new BasicEntityIdParser(),
+			$this->getMock( 'Deserializers\DispatchableDeserializer' )
+		);
+
+		$deserializer = $factory->newEntityDeserializer();
 		$this->assertInstanceOf( 'Deserializers\Deserializer', $deserializer );
 	}
 


### PR DESCRIPTION
To support more entity types we need to be able to pass a
DispatchableDeserializer in here that knows about all entity types, not
only then ones supported by Wikibase DataModel Serialization.

This patch uncouples the component from Wikibase DataModel Serialization.
It might be nice to get rid of that dependency completely.

Bug: [T126932](https://phabricator.wikimedia.org/T126932)