### PR TITLE
Fix documentation and outdated references

### DIFF
--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -19,6 +19,7 @@ use Wikibase\InternalSerialization\Deserializers\StatementDeserializer;
  * legacy internal format and in the new one.
  *
  * @since 1.0
+ *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */

--- a/src/Deserializers/LegacyPropertyDeserializer.php
+++ b/src/Deserializers/LegacyPropertyDeserializer.php
@@ -39,7 +39,7 @@ class LegacyPropertyDeserializer implements Deserializer {
 	 */
 	public function deserialize( $serialization ) {
 		if ( !is_array( $serialization ) ) {
-			throw new DeserializationException( 'Item serialization should be an array' );
+			throw new DeserializationException( 'Property serialization should be an array' );
 		}
 
 		return new Property(

--- a/src/LegacyDeserializerFactory.php
+++ b/src/LegacyDeserializerFactory.php
@@ -18,6 +18,7 @@ use Wikibase\InternalSerialization\Deserializers\LegacyStatementDeserializer;
  * Factory for constructing deserializers that implement handling for the legacy format.
  *
  * @since 1.0
+ *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -10,6 +10,7 @@ namespace Wikibase\InternalSerialization;
  * implementation is returned.
  *
  * @since 1.0
+ *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */

--- a/tests/integration/TestFactoryBuilder.php
+++ b/tests/integration/TestFactoryBuilder.php
@@ -62,7 +62,7 @@ class TestFactoryBuilder {
 			'number' => 'DataValues\NumberValue',
 			'string' => 'DataValues\StringValue',
 			'unknown' => 'DataValues\UnknownValue',
-			'globecoordinate' => 'DataValues\GlobeCoordinateValue',
+			'globecoordinate' => 'DataValues\Geo\Values\GlobeCoordinateValue',
 			'monolingualtext' => 'DataValues\MonolingualTextValue',
 			'multilingualtext' => 'DataValues\MultilingualTextValue',
 			'quantity' => 'DataValues\QuantityValue',


### PR DESCRIPTION
The only relevant change in here is the changed namespace, which is fine. It changed in Geo 1.0, and this component requires Geo 1.1.