### PR TITLE
Make use of DispatchableDeserializer interface

### DIFF
--- a/src/Deserializers/EntityDeserializer.php
+++ b/src/Deserializers/EntityDeserializer.php
@@ -2,7 +2,6 @@
 
 namespace Wikibase\InternalSerialization\Deserializers;
 
-use Deserializers\Deserializer;
 use Deserializers\DispatchableDeserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Wikibase\DataModel\Entity\EntityDocument;
@@ -12,7 +11,7 @@ use Wikibase\DataModel\Entity\EntityDocument;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */
-class EntityDeserializer implements Deserializer {
+class EntityDeserializer implements DispatchableDeserializer {
 
 	/**
 	 * @var DispatchableDeserializer
@@ -39,33 +38,29 @@ class EntityDeserializer implements Deserializer {
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {
-		if ( !is_array( $serialization ) ) {
-			throw new DeserializationException( 'Entity serialization must be an array' );
-		}
-
 		if ( $this->currentDeserializer->isDeserializerFor( $serialization ) ) {
 			return $this->currentDeserializer->deserialize( $serialization );
 		} elseif ( $this->legacyDeserializer->isDeserializerFor( $serialization ) ) {
 			return $this->legacyDeserializer->deserialize( $serialization );
-		} else {
-			return $this->fromUnknownSerialization( $serialization );
 		}
+
+		throw new DeserializationException(
+			'The provided entity serialization is neither legacy nor current'
+		);
 	}
 
-	private function fromUnknownSerialization( array $serialization ) {
-		try {
-			return $this->currentDeserializer->deserialize( $serialization );
-		} catch ( DeserializationException $currentEx ) {
-			try {
-				return $this->legacyDeserializer->deserialize( $serialization );
-			} catch ( DeserializationException $legacyEx ) {
-				throw new DeserializationException(
-					'The provided entity serialization is neither legacy ('
-					. $legacyEx->getMessage() . ') nor current ('
-					. $currentEx->getMessage() . ')'
-				);
-			}
-		}
+	/**
+	 * @see DispatchableDeserializer::isDeserializerFor
+	 *
+	 * @since 2.2
+	 *
+	 * @param mixed $serialization
+	 *
+	 * @return bool
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return $this->currentDeserializer->isDeserializerFor( $serialization )
+			|| $this->legacyDeserializer->isDeserializerFor( $serialization );
 	}
 
 }

--- a/src/Deserializers/LegacyEntityDeserializer.php
+++ b/src/Deserializers/LegacyEntityDeserializer.php
@@ -2,7 +2,6 @@
 
 namespace Wikibase\InternalSerialization\Deserializers;
 
-use Deserializers\Deserializer;
 use Deserializers\DispatchableDeserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Wikibase\DataModel\Entity\EntityDocument;
@@ -14,16 +13,19 @@ use Wikibase\DataModel\Entity\EntityDocument;
 class LegacyEntityDeserializer implements DispatchableDeserializer {
 
 	/**
-	 * @var Deserializer
+	 * @var DispatchableDeserializer
 	 */
 	private $itemDeserializer;
 
 	/**
-	 * @var Deserializer
+	 * @var DispatchableDeserializer
 	 */
 	private $propertyDeserializer;
 
-	public function __construct( Deserializer $itemDeserializer, Deserializer $propertyDeserializer ) {
+	public function __construct(
+		DispatchableDeserializer $itemDeserializer,
+		DispatchableDeserializer $propertyDeserializer
+	) {
 		$this->itemDeserializer = $itemDeserializer;
 		$this->propertyDeserializer = $propertyDeserializer;
 	}
@@ -39,15 +41,11 @@ class LegacyEntityDeserializer implements DispatchableDeserializer {
 			throw new DeserializationException( 'Entity serialization must be an array' );
 		}
 
-		if ( $this->isPropertySerialization( $serialization ) ) {
+		if ( $this->propertyDeserializer->isDeserializerFor( $serialization ) ) {
 			return $this->propertyDeserializer->deserialize( $serialization );
 		}
 
 		return $this->itemDeserializer->deserialize( $serialization );
-	}
-
-	private function isPropertySerialization( $serialization ) {
-		return array_key_exists( 'datatype', $serialization );
 	}
 
 	/**
@@ -60,9 +58,8 @@ class LegacyEntityDeserializer implements DispatchableDeserializer {
 	 * @return bool
 	 */
 	public function isDeserializerFor( $serialization ) {
-		return is_array( $serialization )
-			// This element is called 'id' in the current serialization.
-			&& array_key_exists( 'entity', $serialization );
+		return $this->itemDeserializer->isDeserializerFor( $serialization )
+			|| $this->propertyDeserializer->isDeserializerFor( $serialization );
 	}
 
 }

--- a/src/Deserializers/LegacyItemDeserializer.php
+++ b/src/Deserializers/LegacyItemDeserializer.php
@@ -3,6 +3,7 @@
 namespace Wikibase\InternalSerialization\Deserializers;
 
 use Deserializers\Deserializer;
+use Deserializers\DispatchableDeserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\Exceptions\InvalidAttributeException;
 use Wikibase\DataModel\Entity\Item;
@@ -17,7 +18,7 @@ use Wikibase\DataModel\Statement\StatementList;
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
-class LegacyItemDeserializer implements Deserializer {
+class LegacyItemDeserializer implements DispatchableDeserializer {
 
 	/**
 	 * @var Deserializer
@@ -168,6 +169,22 @@ class LegacyItemDeserializer implements Deserializer {
 		}
 
 		return $serialization[$key];
+	}
+
+	/**
+	 * @see DispatchableDeserializer::isDeserializerFor
+	 *
+	 * @since 2.2
+	 *
+	 * @param mixed $serialization
+	 *
+	 * @return bool
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return is_array( $serialization )
+			// This element is called 'id' in the current serialization.
+			&& array_key_exists( 'entity', $serialization )
+			&& !array_key_exists( 'datatype', $serialization );
 	}
 
 }

--- a/src/Deserializers/LegacyPropertyDeserializer.php
+++ b/src/Deserializers/LegacyPropertyDeserializer.php
@@ -3,6 +3,7 @@
 namespace Wikibase\InternalSerialization\Deserializers;
 
 use Deserializers\Deserializer;
+use Deserializers\DispatchableDeserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\Exceptions\InvalidAttributeException;
 use Deserializers\Exceptions\MissingAttributeException;
@@ -14,7 +15,7 @@ use Wikibase\DataModel\Entity\PropertyId;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
-class LegacyPropertyDeserializer implements Deserializer {
+class LegacyPropertyDeserializer implements DispatchableDeserializer {
 
 	/**
 	 * @var Deserializer
@@ -94,6 +95,22 @@ class LegacyPropertyDeserializer implements Deserializer {
 		}
 
 		return $serialization['datatype'];
+	}
+
+	/**
+	 * @see DispatchableDeserializer::isDeserializerFor
+	 *
+	 * @since 2.2
+	 *
+	 * @param mixed $serialization
+	 *
+	 * @return bool
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return is_array( $serialization )
+			// This element is called 'id' in the current serialization.
+			&& array_key_exists( 'entity', $serialization )
+			&& array_key_exists( 'datatype', $serialization );
 	}
 
 }

--- a/tests/integration/LegacyDeserializerFactoryTest.php
+++ b/tests/integration/LegacyDeserializerFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Integration\Wikibase\InternalSerialization;
 
 use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\InternalSerialization\LegacyDeserializerFactory;
 
@@ -25,8 +26,11 @@ class LegacyDeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testEntityDeserializer() {
 		$this->assertEquals(
-			Property::newFromType( 'foo' ),
-			$this->factory->newEntityDeserializer()->deserialize( array( 'datatype' => 'foo' ) )
+			new Property( new PropertyId( 'P1' ), null, 'foo' ),
+			$this->factory->newEntityDeserializer()->deserialize( array(
+				'entity' => array( 'property', 1 ),
+				'datatype' => 'foo',
+			) )
 		);
 	}
 

--- a/tests/unit/Deserializers/EntityDeserializerTest.php
+++ b/tests/unit/Deserializers/EntityDeserializerTest.php
@@ -88,15 +88,14 @@ class EntityDeserializerTest extends \PHPUnit_Framework_TestCase {
 		return $currentDeserializer;
 	}
 
-	public function testLegacySerializationWithoutId_legacyIsDetected() {
+	public function testLegacySerializationWithoutId_exceptionIsThrown() {
 		$deserializer = new EntityDeserializer(
 			$this->getStubLegacyDeserializer(),
 			$this->getThrowingDeserializer()
 		);
 
-		$returnValue = $deserializer->deserialize( $this->getLegacyItemSerializationWithoutId() );
-
-		$this->assertEquals( 'legacy', $returnValue );
+		$this->setExpectedException( 'Deserializers\Exceptions\DeserializationException' );
+		$deserializer->deserialize( $this->getLegacyItemSerializationWithoutId() );
 	}
 
 	private function getLegacyItemSerializationWithoutId() {
@@ -105,15 +104,14 @@ class EntityDeserializerTest extends \PHPUnit_Framework_TestCase {
 		) );
 	}
 
-	public function testCurrentSerializationWithoutId_currentIsDetected() {
+	public function testCurrentSerializationWithoutId_exceptionIsThrown() {
 		$deserializer = new EntityDeserializer(
 			$this->getThrowingDeserializer(),
 			$this->getStubCurrentDeserializer()
 		);
 
-		$returnValue = $deserializer->deserialize( $this->getCurrentItemSerializationWithoutId() );
-
-		$this->assertEquals( 'current', $returnValue );
+		$this->setExpectedException( 'Deserializers\Exceptions\DeserializationException' );
+		$deserializer->deserialize( $this->getCurrentItemSerializationWithoutId() );
 	}
 
 	private function getCurrentItemSerializationWithoutId() {


### PR DESCRIPTION
- ~~I want to get rid of code that's now duplicated.~~ Done.
- ~~I'm not sure if this is a breaking change. Depends. Is one of the changed constructor public?~~ Nothing is public, so not a breaking change.
- ~~Tests.~~ No new tests needed, this is all private implementation detail.
- ~~Drop duplicate fromUnknownSerialization code.~~ Done. Note that this made this patch a breaking change. Now the legacy serialization is **only** recognized when an `entity` id is set. This should not make a difference, because our database can not contain legacy serializations with no entity id. Serializations with no entity id are only accepted via the API, but this should **not** accept legacy serializations. So technically a breaking change, from this components point of view, but not in Wikibase.git.
