### PR TITLE
Turn LegacyEntity/StatementDeserializers into DispatchableDeserializers

### DIFF
--- a/src/Deserializers/EntityDeserializer.php
+++ b/src/Deserializers/EntityDeserializer.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Entity\EntityDocument;
 class EntityDeserializer implements Deserializer {
 
 	/**
-	 * @var Deserializer
+	 * @var DispatchableDeserializer
 	 */
 	private $legacyDeserializer;
 
@@ -25,7 +25,7 @@ class EntityDeserializer implements Deserializer {
 	private $currentDeserializer;
 
 	public function __construct(
-		Deserializer $legacyDeserializer,
+		DispatchableDeserializer $legacyDeserializer,
 		DispatchableDeserializer $currentDeserializer
 	) {
 		$this->legacyDeserializer = $legacyDeserializer;
@@ -45,16 +45,11 @@ class EntityDeserializer implements Deserializer {
 
 		if ( $this->currentDeserializer->isDeserializerFor( $serialization ) ) {
 			return $this->currentDeserializer->deserialize( $serialization );
-		} elseif ( $this->isLegacySerialization( $serialization ) ) {
+		} elseif ( $this->legacyDeserializer->isDeserializerFor( $serialization ) ) {
 			return $this->legacyDeserializer->deserialize( $serialization );
 		} else {
 			return $this->fromUnknownSerialization( $serialization );
 		}
-	}
-
-	private function isLegacySerialization( array $serialization ) {
-		// This element is called 'id' in the current serialization.
-		return array_key_exists( 'entity', $serialization );
 	}
 
 	private function fromUnknownSerialization( array $serialization ) {

--- a/src/Deserializers/LegacyEntityDeserializer.php
+++ b/src/Deserializers/LegacyEntityDeserializer.php
@@ -3,6 +3,7 @@
 namespace Wikibase\InternalSerialization\Deserializers;
 
 use Deserializers\Deserializer;
+use Deserializers\DispatchableDeserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Wikibase\DataModel\Entity\EntityDocument;
 
@@ -10,7 +11,7 @@ use Wikibase\DataModel\Entity\EntityDocument;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class LegacyEntityDeserializer implements Deserializer {
+class LegacyEntityDeserializer implements DispatchableDeserializer {
 
 	/**
 	 * @var Deserializer
@@ -47,6 +48,21 @@ class LegacyEntityDeserializer implements Deserializer {
 
 	private function isPropertySerialization( $serialization ) {
 		return array_key_exists( 'datatype', $serialization );
+	}
+
+	/**
+	 * @see DispatchableDeserializer::isDeserializerFor
+	 *
+	 * @since 2.2
+	 *
+	 * @param mixed $serialization
+	 *
+	 * @return bool
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return is_array( $serialization )
+			// This element is called 'id' in the current serialization.
+			&& array_key_exists( 'entity', $serialization );
 	}
 
 }

--- a/src/Deserializers/LegacyStatementDeserializer.php
+++ b/src/Deserializers/LegacyStatementDeserializer.php
@@ -3,6 +3,7 @@
 namespace Wikibase\InternalSerialization\Deserializers;
 
 use Deserializers\Deserializer;
+use Deserializers\DispatchableDeserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\Exceptions\MissingAttributeException;
 use InvalidArgumentException;
@@ -16,7 +17,7 @@ use Wikibase\DataModel\Statement\Statement;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */
-class LegacyStatementDeserializer implements Deserializer {
+class LegacyStatementDeserializer implements DispatchableDeserializer {
 
 	/**
 	 * @var Deserializer
@@ -84,6 +85,21 @@ class LegacyStatementDeserializer implements Deserializer {
 		}
 
 		return new ReferenceList( $references );
+	}
+
+	/**
+	 * @see DispatchableDeserializer::isDeserializerFor
+	 *
+	 * @since 2.2
+	 *
+	 * @param mixed $serialization
+	 *
+	 * @return bool
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return is_array( $serialization )
+			// This element is called 'mainsnak' in the current serialization.
+			&& array_key_exists( 'm', $serialization );
 	}
 
 }

--- a/src/Deserializers/StatementDeserializer.php
+++ b/src/Deserializers/StatementDeserializer.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Statement\Statement;
 class StatementDeserializer implements Deserializer {
 
 	/**
-	 * @var Deserializer
+	 * @var DispatchableDeserializer
 	 */
 	private $legacyDeserializer;
 
@@ -25,7 +25,7 @@ class StatementDeserializer implements Deserializer {
 	private $currentDeserializer;
 
 	public function __construct(
-		Deserializer $legacyDeserializer,
+		DispatchableDeserializer $legacyDeserializer,
 		DispatchableDeserializer $currentDeserializer
 	) {
 		$this->legacyDeserializer = $legacyDeserializer;
@@ -45,16 +45,11 @@ class StatementDeserializer implements Deserializer {
 
 		if ( $this->currentDeserializer->isDeserializerFor( $serialization ) ) {
 			return $this->currentDeserializer->deserialize( $serialization );
-		} elseif ( $this->isLegacySerialization( $serialization ) ) {
+		} elseif ( $this->legacyDeserializer->isDeserializerFor( $serialization ) ) {
 			return $this->legacyDeserializer->deserialize( $serialization );
 		} else {
 			return $this->fromUnknownSerialization( $serialization );
 		}
-	}
-
-	private function isLegacySerialization( array $serialization ) {
-		// This element is called 'mainsnak' in the current serialization.
-		return array_key_exists( 'm', $serialization );
 	}
 
 	private function fromUnknownSerialization( array $serialization ) {

--- a/tests/unit/Deserializers/EntityDeserializerTest.php
+++ b/tests/unit/Deserializers/EntityDeserializerTest.php
@@ -27,7 +27,13 @@ class EntityDeserializerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function getStubLegacyDeserializer() {
-		$legacyDeserializer = $this->getMock( 'Deserializers\Deserializer' );
+		$legacyDeserializer = $this->getMock( 'Deserializers\DispatchableDeserializer' );
+
+		$legacyDeserializer->expects( $this->any() )
+			->method( 'isDeserializerFor' )
+			->will( $this->returnCallback( function( $serialization ) {
+				return array_key_exists( 'entity', $serialization );
+			} ) );
 
 		$legacyDeserializer->expects( $this->any() )
 			->method( 'deserialize' )

--- a/tests/unit/Deserializers/StatementDeserializerTest.php
+++ b/tests/unit/Deserializers/StatementDeserializerTest.php
@@ -20,7 +20,7 @@ class StatementDeserializerTest extends PHPUnit_Framework_TestCase {
 	private $deserializer;
 
 	protected function setUp() {
-		$legacyDeserializer = $this->getMock( 'Deserializers\Deserializer' );
+		$legacyDeserializer = $this->getMock( 'Deserializers\DispatchableDeserializer' );
 		$currentDeserializer = $this->getMock( 'Deserializers\DispatchableDeserializer' );
 		$this->deserializer = new StatementDeserializer( $legacyDeserializer, $currentDeserializer );
 	}


### PR DESCRIPTION
This is the most minimal patch, split from #98, that moves the two misplaced `isLegacySerialization` methods to their corresponding Legacy…Deserializer. This is pure refactoring that only moves existing code around. The only substantial change is that two `is_array` are added. All this is non-breaking, because all these classes are considered package-private.