### PR TITLE
Add missing return types to private methods

### DIFF
--- a/tests/integration/TestFactoryBuilder.php
+++ b/tests/integration/TestFactoryBuilder.php
@@ -5,6 +5,7 @@ namespace Tests\Integration\Wikibase\InternalSerialization;
 use DataValues\Deserializers\DataValueDeserializer;
 use DataValues\Serializers\DataValueSerializer;
 use DataValues\StringValue;
+use Deserializers\Deserializer;
 use PHPUnit_Framework_TestCase;
 use Wikibase\DataModel\Entity\BasicEntityIdParser;
 use Wikibase\InternalSerialization\DeserializerFactory;
@@ -24,6 +25,11 @@ class TestFactoryBuilder {
 		);
 	}
 
+	/**
+	 * @param PHPUnit_Framework_TestCase $testCase
+	 *
+	 * @return Deserializer
+	 */
 	private static function newFakeDataValueDeserializer( PHPUnit_Framework_TestCase $testCase ) {
 		$dataValueDeserializer = $testCase->getMock( 'Deserializers\Deserializer' );
 

--- a/tests/unit/Deserializers/EntityDeserializerTest.php
+++ b/tests/unit/Deserializers/EntityDeserializerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Wikibase\InternalSerialization\Deserializers;
 
 use Deserializers\Deserializer;
+use Deserializers\DispatchableDeserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Wikibase\InternalSerialization\Deserializers\EntityDeserializer;
 
@@ -26,6 +27,9 @@ class EntityDeserializerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	/**
+	 * @return DispatchableDeserializer
+	 */
 	private function getStubLegacyDeserializer() {
 		$legacyDeserializer = $this->getMock( 'Deserializers\DispatchableDeserializer' );
 
@@ -42,6 +46,9 @@ class EntityDeserializerTest extends \PHPUnit_Framework_TestCase {
 		return $legacyDeserializer;
 	}
 
+	/**
+	 * @return DispatchableDeserializer
+	 */
 	private function getStubCurrentDeserializer() {
 		$currentDeserializer = $this->getMock( 'Deserializers\DispatchableDeserializer' );
 
@@ -68,6 +75,9 @@ class EntityDeserializerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'current', $returnValue );
 	}
 
+	/**
+	 * @return DispatchableDeserializer
+	 */
 	private function getThrowingDeserializer() {
 		$currentDeserializer = $this->getMock( 'Deserializers\DispatchableDeserializer' );
 


### PR DESCRIPTION
Callers of these methods do not need to know that they are getting a mock. This fixes warnings in PHPStorm's code analysis.