### PR TITLE
Update DataValues Number to 0.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"phpmd/phpmd": "~2.3",
 		"data-values/common": "~0.3.0|~0.2.0",
 		"data-values/geo": "~1.1",
-		"data-values/number": "~0.5.0",
+		"data-values/number": ">=0.1 <0.9",
 		"data-values/time": "~0.7.0"
 	},
 	"autoload": {


### PR DESCRIPTION
Note that this is in the `require-dev` section and not critical for anything. The only detail this component cares about is if the QuantityValue class exists or not, which is the case in all versions. This is mostly for consistency and does not need a release.
