### PR TITLE
Release 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       php: 5.6
     - env: DM=~4.2
       php: 7
-    - env: DM=~4.2
+    - env: DM=~7.0
       php: hhvm
   exclude:
     - env: THENEEDFORTHIS=FAIL

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Wikibase Internal Serialization has been written by [Jeroen De Dauw]
 
 ## Release notes
 
-### 2.4.0 (2017-03-15)
+### 2.4.0 (2017-03-16)
 
 * Added compatibility with Wikibase DataModel 7.x
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Wikibase Internal Serialization has been written by [Jeroen De Dauw]
 
 ## Release notes
 
+### 2.4.0 (2017-03-15)
+
+* Added compatibility with Wikibase DataModel 7.x
+
 ### 2.3.0 (2016-03-14)
 
 * Added compatibility with Wikibase DataModel 6.x

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,14 @@
 	},
 	"require": {
 		"php": ">=5.3.0",
-		"wikibase/data-model": "~6.0|~5.0|~4.2",
+		"wikibase/data-model": "~7.0|~6.0|~5.0|~4.2",
 		"wikibase/data-model-serialization": "~2.0",
 		"serialization/serialization": "~3.2"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.3",
 		"phpmd/phpmd": "~2.3",
+		"phpunit/phpunit": "~4.8",
 		"data-values/common": "~0.3.0|~0.2.0",
 		"data-values/geo": "~1.1",
 		"data-values/number": ">=0.1 <0.9",
@@ -51,16 +52,16 @@
 	},
 	"scripts": {
 		"test": [
-			"composer validate --no-interaction",
-			"phpunit"
+			"@validate --no-interaction",
+			"vendor/bin/phpunit"
 		],
 		"cs": [
-			"composer phpcs",
-			"composer phpmd"
+			"@phpcs",
+			"@phpmd"
 		],
 		"ci": [
-			"composer test",
-			"composer cs"
+			"@test",
+			"@cs"
 		],
 		"phpcs": [
 			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp"

--- a/mediawiki-extension.json
+++ b/mediawiki-extension.json
@@ -5,7 +5,7 @@
 	],
 	"url": "https://github.com/wmde/WikibaseInternalSerialization",
 	"description": "Serializers and deserializers for the data access layer of Wikibase Repository",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"license-name": "GPL-2.0+",
 	"type": "wikibase",
 	"manifest_version": 1


### PR DESCRIPTION
This depends on https://github.com/wmde/WikibaseDataModelSerialization/pull/218 being released first. No other change needs to be done here. Just retrigger the tests.