### PR TITLE
Require PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,12 @@ env:
 matrix:
   fast_finish: true
   include:
-    - env: DM=~6.0
-      php: 5.3
-    - env: DM=~6.0
-      php: 5.4
     - env: DM=@dev
       php: 5.5
     - env: DM=~5.0
       php: 5.6
+    - env: DM=~6.0
+      php: 7
     - env: DM=~4.2
       php: 7.1
     - env: DM=~7.0

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.3.0",
+		"php": ">=5.5.9",
 		"wikibase/data-model": "~7.0|~6.0|~5.0|~4.2",
 		"wikibase/data-model-serialization": "~2.0",
 		"serialization/serialization": "~3.2"


### PR DESCRIPTION
This drops support for PHP 5.3 and 5.4.

This brings back the test run with PHP 7.0, which was removed in #112.