### PR TITLE
Remove non-standard Composer commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,21 +53,15 @@
 	"scripts": {
 		"test": [
 			"@validate --no-interaction",
-			"vendor/bin/phpunit"
+			"phpunit"
 		],
 		"cs": [
-			"@phpcs",
-			"@phpmd"
+			"phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp",
+			"phpmd src/ text phpmd.xml"
 		],
 		"ci": [
-			"@test",
-			"@cs"
-		],
-		"phpcs": [
-			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp"
-		],
-		"phpmd": [
-			"vendor/bin/phpmd src/ text phpmd.xml"
+			"@cs",
+			"@test"
 		]
 	}
 }


### PR DESCRIPTION
I'm reducing the confusing number of Composer commands to "cs", "test", and "ci". Usually, PHPCS is executed before PHPUnit. This patch also makes sure this order is consistent.