### PR TITLE
Use Wikibase's CodeSniffer instead of MediaWiki's

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
 		"serialization/serialization": "~3.2"
 	},
 	"require-dev": {
-		"squizlabs/php_codesniffer": "~2.3",
 		"phpmd/phpmd": "~2.3",
 		"phpunit/phpunit": "~4.8",
 		"data-values/common": "~0.3.0|~0.2.0",
 		"data-values/geo": "~1.1|~2.0",
 		"data-values/number": ">=0.1 <0.9",
-		"data-values/time": "~0.7.0"
+		"data-values/time": "~0.7.0",
+		"wikibase/wikibase-codesniffer": "^0.1.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,110 +1,25 @@
 <?xml version="1.0"?>
-<!--
-	- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
-	- https://github.com/squizlabs/PHP_CodeSniffer/tree/master/CodeSniffer/Standards
--->
 <ruleset name="WikibaseInternalSerialization">
-    <rule ref="Generic.Classes" />
-    <rule ref="Generic.CodeAnalysis" />
-    <rule ref="Generic.ControlStructures" />
+	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase">
+		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
+		<exclude name="MediaWiki.ControlStructures.IfElseStructure" />
+		<exclude name="Squiz.ControlStructures.ControlSignature" />
+	</rule>
 
-    <rule ref="Generic.Files.ByteOrderMark" />
-    <rule ref="Generic.Files.EndFileNewline" />
-    <rule ref="Generic.Files.InlineHTML" />
-    <rule ref="Generic.Files.LineEndings" />
-    <rule ref="Generic.Files.LineLength">
-        <properties>
-            <property name="lineLimit" value="120" />
-            <property name="absoluteLineLimit" value="120" />
-        </properties>
-    </rule>
-    <rule ref="Generic.Files.OneClassPerFile" />
-    <rule ref="Generic.Files.OneInterfacePerFile" />
-    <rule ref="Generic.Files.OneTraitPerFile" />
+	<rule ref="Generic.CodeAnalysis" />
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<property name="lineLimit" value="117" />
+		</properties>
+	</rule>
 
-    <rule ref="Generic.Formatting.DisallowMultipleStatements" />
+	<rule ref="Generic.Metrics.NestingLevel" />
+	<rule ref="Generic.Metrics.CyclomaticComplexity" />
 
-    <rule ref="Generic.Functions.CallTimePassByReference" />
-    <rule ref="Generic.Functions.FunctionCallArgumentSpacing" />
-    <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
+	<rule ref="PSR1.Files.SideEffects" />
+	<rule ref="Squiz.Strings.DoubleQuoteUsage">
+		<exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
+	</rule>
 
-    <rule ref="Generic.Metrics.NestingLevel">
-        <properties>
-            <property name="nestingLevel" value="3" />
-            <property name="absoluteNestingLevel" value="3" />
-        </properties>
-    </rule>
-
-    <rule ref="Generic.Metrics.CyclomaticComplexity">
-        <properties>
-            <property name="complexity" value="10" />
-            <property name="absoluteComplexity" value="10" />
-        </properties>
-    </rule>
-
-    <rule ref="Generic.NamingConventions" />
-    <rule ref="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps">
-        <!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
-        <exclude-pattern>tests*Test\.php</exclude-pattern>
-    </rule>
-
-    <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
-    <rule ref="Generic.PHP.DeprecatedFunctions" />
-    <rule ref="Generic.PHP.DisallowShortOpenTag" />
-    <rule ref="Generic.PHP.ForbiddenFunctions" />
-    <rule ref="Generic.PHP.LowerCaseConstant" />
-    <rule ref="Generic.PHP.LowerCaseKeyword" />
-    <rule ref="Generic.PHP.NoSilencedErrors" />
-    <rule ref="Generic.PHP.SAPIUsage" />
-
-    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent" />
-
-    <rule ref="PSR1" />
-    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
-        <!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
-        <exclude-pattern>tests*Test\.php</exclude-pattern>
-    </rule>
-
-    <rule ref="PSR2.Classes.PropertyDeclaration" />
-    <rule ref="PSR2.ControlStructures.ElseIfDeclaration" />
-    <rule ref="PSR2.Files" />
-    <rule ref="PSR2.Namespaces" />
-
-    <rule ref="Squiz.Arrays.ArrayBracketSpacing" />
-    <rule ref="Squiz.CSS.SemicolonSpacing" />
-    <rule ref="Squiz.Classes.DuplicateProperty" />
-    <rule ref="Squiz.Classes.SelfMemberReference" />
-    <rule ref="Squiz.Classes.ValidClassName" />
-    <rule ref="Squiz.Functions.FunctionDuplicateArgument" />
-    <rule ref="Squiz.Functions.GlobalFunction" />
-    <rule ref="Squiz.Scope" />
-
-    <rule ref="Squiz.Strings.DoubleQuoteUsage" />
-    <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
-        <severity>0</severity>
-    </rule>
-
-    <rule ref="Squiz.WhiteSpace.CastSpacing" />
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing" />
-    <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing" />
-    <rule ref="Squiz.WhiteSpace.FunctionSpacing">
-        <properties>
-            <property name="spacing" value="1" />
-        </properties>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
-        <properties>
-            <property name="ignoreNewlines" value="true" />
-        </properties>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace" />
-    <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing" />
-    <rule ref="Squiz.WhiteSpace.SemicolonSpacing" />
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace" />
-
-    <rule ref="Zend.Files.ClosingTag" />
-
-    <arg name="extensions" value="php" />
-    <exclude-pattern type="relative">^vendor/</exclude-pattern>
-    <file>.</file>
+	<file>.</file>
 </ruleset>


### PR DESCRIPTION
I used `phpcs -e` to make sure no relevant sniff gets lost. The differences are:
* I had to remove Generic.Classes.OpeningBraceSameLine because it does not exist in PHPCS 2.6. It's redundant anyway because other MediaWiki sniffs are checking the same.
* I removed Generic.NamingConventions.CamelCapsFunctionName because its redundant to PSR1.Methods.CamelCapsMethodName.
* I had to remove Squiz.Arrays.ArrayBracketSpacing because it conflicts with the MediaWiki style guide.
* Having Squiz.Classes.DuplicateProperty was a mistake because it's a JS-only sniff.

All other sniffs are still there.

[Bug: T167436](https://phabricator.wikimedia.org/T167436)