### PR TITLE
Release 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Wikibase Internal Serialization has been written by [Jeroen De Dauw]
 
 ## Release notes
 
-### 2.6.0 (2017-09-15)
+### 2.6.0 (2017-09-18)
 
 * Added compatibility with DataValues Common 0.4, Number 0.9, and Time 0.8
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Wikibase Internal Serialization has been written by [Jeroen De Dauw]
 
 ## Release notes
 
+### 2.6.0 (2017-09-15)
+
+* Added compatibility with DataValues Common 0.4, Number 0.9, and Time 0.8
+
 ### 2.5.0 (2017-08-30)
 
 * Added compatibility with DataValues Geo 2.x

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.5.x-dev"
+			"dev-master": "2.6.x-dev"
 		}
 	},
 	"scripts": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0"?>
 <ruleset name="WikibaseInternalSerialization">
-	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase">
+	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase">
 		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
-		<exclude name="MediaWiki.ControlStructures.IfElseStructure" />
-		<exclude name="Squiz.ControlStructures.ControlSignature" />
 	</rule>
 
 	<rule ref="Generic.CodeAnalysis" />
 	<rule ref="Generic.Files.LineLength">
 		<properties>
-			<property name="lineLimit" value="117" />
+			<property name="lineLimit" value="114" />
 		</properties>
 	</rule>
 

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -10,7 +10,7 @@
     </rule>
     <rule ref="rulesets/codesize.xml/TooManyMethods">
         <properties>
-            <property name="maxmethods" value="20" />
+            <property name="maxmethods" value="11" />
         </properties>
     </rule>
 
@@ -22,7 +22,7 @@
     </rule>
     <rule ref="rulesets/design.xml/CouplingBetweenObjects">
         <properties>
-            <property name="minimum" value="14" />
+            <property name="minimum" value="13" />
         </properties>
     </rule>
 

--- a/src/Deserializers/LegacyEntityIdDeserializer.php
+++ b/src/Deserializers/LegacyEntityIdDeserializer.php
@@ -34,11 +34,9 @@ class LegacyEntityIdDeserializer implements Deserializer {
 	public function deserialize( $serialization ) {
 		if ( is_string( $serialization ) ) {
 			return $this->getParsedId( $serialization );
-		}
-		elseif ( $this->isLegacyFormat( $serialization ) ) {
+		} elseif ( $this->isLegacyFormat( $serialization ) ) {
 			return $this->getIdFromLegacyFormat( $serialization );
-		}
-		else {
+		} else {
 			throw new DeserializationException( 'Entity id format not recognized' );
 		}
 	}
@@ -51,8 +49,7 @@ class LegacyEntityIdDeserializer implements Deserializer {
 	private function getParsedId( $serialization ) {
 		try {
 			return $this->idParser->parse( $serialization );
-		}
-		catch ( EntityIdParsingException $ex ) {
+		} catch ( EntityIdParsingException $ex ) {
 			throw new DeserializationException( $ex->getMessage(), $ex );
 		}
 	}
@@ -60,8 +57,7 @@ class LegacyEntityIdDeserializer implements Deserializer {
 	private function getIdFromLegacyFormat( array $serialization ) {
 		try {
 			return LegacyIdInterpreter::newIdFromTypeAndNumber( $serialization[0], $serialization[1] );
-		}
-		catch ( InvalidArgumentException $ex ) {
+		} catch ( InvalidArgumentException $ex ) {
 			throw new DeserializationException( $ex->getMessage(), $ex );
 		}
 	}

--- a/src/Deserializers/LegacyFingerprintDeserializer.php
+++ b/src/Deserializers/LegacyFingerprintDeserializer.php
@@ -37,8 +37,7 @@ class LegacyFingerprintDeserializer implements Deserializer {
 				$this->getDescriptions( $serialization ),
 				$this->getAliases( $serialization )
 			);
-		}
-		catch ( InvalidArgumentException $ex ) {
+		} catch ( InvalidArgumentException $ex ) {
 			throw new DeserializationException(
 				'Could not deserialize fingerprint: ' . $ex->getMessage(),
 				$ex

--- a/src/Deserializers/LegacySiteLinkListDeserializer.php
+++ b/src/Deserializers/LegacySiteLinkListDeserializer.php
@@ -90,8 +90,7 @@ class LegacySiteLinkListDeserializer implements Deserializer {
 	private function newSiteLinkFromSerialization( $siteId, $siteLinkData ) {
 		try {
 			return $this->tryNewSiteLinkFromSerialization( $siteId, $siteLinkData );
-		}
-		catch ( InvalidArgumentException $ex ) {
+		} catch ( InvalidArgumentException $ex ) {
 			throw new DeserializationException( $ex->getMessage(), $ex );
 		}
 	}
@@ -106,8 +105,7 @@ class LegacySiteLinkListDeserializer implements Deserializer {
 		if ( is_array( $siteLinkData ) ) {
 			$pageName = $siteLinkData['name'];
 			$badges = $this->getDeserializedBadges( $siteLinkData['badges'] );
-		}
-		else {
+		} else {
 			$pageName = $siteLinkData;
 			$badges = array();
 		}

--- a/src/Deserializers/LegacySnakDeserializer.php
+++ b/src/Deserializers/LegacySnakDeserializer.php
@@ -76,8 +76,7 @@ class LegacySnakDeserializer implements Deserializer {
 
 		if ( $serialization[0] === 'value' ) {
 			$this->assertIsValueSnak( $serialization );
-		}
-		else {
+		} else {
 			$this->assertIsNonValueSnak( $serialization );
 		}
 

--- a/tests/integration/Deserializers/StatementDeserializerTest.php
+++ b/tests/integration/Deserializers/StatementDeserializerTest.php
@@ -31,7 +31,8 @@ class StatementDeserializerTest extends \PHPUnit_Framework_TestCase {
 	private $currentSerializer;
 
 	protected function setUp() {
-		$this->deserializer = TestFactoryBuilder::newDeserializerFactoryWithDataValueSupport()->newStatementDeserializer();
+		$this->deserializer = TestFactoryBuilder::newDeserializerFactoryWithDataValueSupport()
+			->newStatementDeserializer();
 		$this->currentSerializer = TestFactoryBuilder::newSerializerFactory()->newStatementSerializer();
 	}
 


### PR DESCRIPTION
I checked [the diff since 2.5](https://github.com/wmde/WikibaseInternalSerialization/compare/2.5.0...master) and there really is nothing else worth mentioning in the release notes.

I used the opportunity to update the PHPCS as well as PHPMD rule sets a little bit.
* Removing the newlines from the `} else` and `} catch` structures allows to get rid of two exclusions from the PHPCS rule set.
* I reduced the line length to a limit where I only had to split a single line of code. Could be reduced further in later patches – but I really did not wanted this patch here to grow to big.