### PR TITLE
Release 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Wikibase Internal Serialization has been written by [Jeroen De Dauw]
 
 ## Release notes
 
+### 2.7.0 (2017-10-25)
+
+* Added compatibility with Serialization 4.x
+
 ### 2.6.0 (2017-09-18)
 
 * Added compatibility with DataValues Common 0.4, Number 0.9, and Time 0.8

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"php": ">=5.5.9",
 		"wikibase/data-model": "~7.0|~6.0|~5.0|~4.2",
 		"wikibase/data-model-serialization": "~2.0",
-		"serialization/serialization": "~3.2"
+		"serialization/serialization": "~4.0|~3.2"
 	},
 	"require-dev": {
 		"phpmd/phpmd": "~2.3",
@@ -35,7 +35,7 @@
 		"data-values/geo": ">=1.0 <3.0",
 		"data-values/number": ">=0.1 <0.10",
 		"data-values/time": ">=0.1 <0.9",
-		"wikibase/wikibase-codesniffer": "^0.1.0"
+		"wikibase/wikibase-codesniffer": "^0.2.0"
 	},
 	"autoload": {
 		"psr-4": {
@@ -44,7 +44,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.6.x-dev"
+			"dev-master": "2.7.x-dev"
 		}
 	},
 	"scripts": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="WikibaseInternalSerialization">
+<ruleset>
 	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase">
 		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
 	</rule>

--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -37,7 +37,7 @@ class DeserializerFactory {
 	private $currentFactory;
 
 	/**
-	 * @var DispatchableDeserializer|null $currentEntityDeserializer
+	 * @var DispatchableDeserializer|null
 	 */
 	private $currentEntityDeserializer;
 


### PR DESCRIPTION
I think #123 caused a little confusion, but this here was the real reason I started touching this code base again.

DataModel Serialization will also get the same update (see https://github.com/wmde/WikibaseDataModelSerialization/pull/243), but the new version we are going to release there is already included in the `~2.0` version range here.