### PR TITLE
Update Wikibase PHPCS rule set to latest release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"data-values/geo": ">=1.0 <4.0",
 		"data-values/number": ">=0.1 <0.10",
 		"data-values/time": ">=0.1 <0.9",
-		"wikibase/wikibase-codesniffer": "^0.2.0"
+		"wikibase/wikibase-codesniffer": "^0.5.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,7 @@
 <ruleset>
 	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase">
 		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
+		<exclude name="Wikibase.Namespaces.FullQualifiedClassName" />
 	</rule>
 
 	<rule ref="Generic.CodeAnalysis" />

--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -21,7 +21,7 @@ use Wikibase\InternalSerialization\Deserializers\StatementDeserializer;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DeserializerFactory {

--- a/src/Deserializers/EntityDeserializer.php
+++ b/src/Deserializers/EntityDeserializer.php
@@ -8,7 +8,7 @@ use Deserializers\Exceptions\DeserializationException;
 use Wikibase\DataModel\Entity\EntityDocument;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/Deserializers/LegacyEntityDeserializer.php
+++ b/src/Deserializers/LegacyEntityDeserializer.php
@@ -8,7 +8,7 @@ use Deserializers\Exceptions\DeserializationException;
 use Wikibase\DataModel\Entity\EntityDocument;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacyEntityDeserializer implements DispatchableDeserializer {

--- a/src/Deserializers/LegacyEntityIdDeserializer.php
+++ b/src/Deserializers/LegacyEntityIdDeserializer.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\EntityIdParser;
 use Wikibase\DataModel\Entity\EntityIdParsingException;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacyEntityIdDeserializer implements Deserializer {

--- a/src/Deserializers/LegacyFingerprintDeserializer.php
+++ b/src/Deserializers/LegacyFingerprintDeserializer.php
@@ -14,7 +14,7 @@ use Wikibase\DataModel\Term\Term;
 use Wikibase\DataModel\Term\TermList;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */

--- a/src/Deserializers/LegacyItemDeserializer.php
+++ b/src/Deserializers/LegacyItemDeserializer.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >

--- a/src/Deserializers/LegacyPropertyDeserializer.php
+++ b/src/Deserializers/LegacyPropertyDeserializer.php
@@ -10,7 +10,7 @@ use Wikibase\DataModel\Entity\Property;
 use Wikibase\DataModel\Entity\PropertyId;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */

--- a/src/Deserializers/LegacySiteLinkListDeserializer.php
+++ b/src/Deserializers/LegacySiteLinkListDeserializer.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\SiteLinkList;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacySiteLinkListDeserializer implements Deserializer {

--- a/src/Deserializers/LegacySnakDeserializer.php
+++ b/src/Deserializers/LegacySnakDeserializer.php
@@ -13,7 +13,7 @@ use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Snak\Snak;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacySnakDeserializer implements Deserializer {

--- a/src/Deserializers/LegacySnakListDeserializer.php
+++ b/src/Deserializers/LegacySnakListDeserializer.php
@@ -7,7 +7,7 @@ use Deserializers\Exceptions\DeserializationException;
 use Wikibase\DataModel\Snak\SnakList;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacySnakListDeserializer implements Deserializer {

--- a/src/Deserializers/LegacyStatementDeserializer.php
+++ b/src/Deserializers/LegacyStatementDeserializer.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\ReferenceList;
 use Wikibase\DataModel\Statement\Statement;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >

--- a/src/Deserializers/StatementDeserializer.php
+++ b/src/Deserializers/StatementDeserializer.php
@@ -8,7 +8,7 @@ use Deserializers\Exceptions\DeserializationException;
 use Wikibase\DataModel\Statement\Statement;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/LegacyDeserializerFactory.php
+++ b/src/LegacyDeserializerFactory.php
@@ -20,7 +20,7 @@ use Wikibase\InternalSerialization\Deserializers\LegacyStatementDeserializer;
  *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacyDeserializerFactory {

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -9,9 +9,10 @@ namespace Wikibase\InternalSerialization;
  * is "Serializer". You are also not allowed to know which concrete
  * implementation is returned.
  *
+ *
  * @since 1.0
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SerializerFactory extends \Wikibase\DataModel\SerializerFactory {

--- a/tests/integration/DeserializerFactoryTest.php
+++ b/tests/integration/DeserializerFactoryTest.php
@@ -10,7 +10,7 @@ use Wikibase\InternalSerialization\DeserializerFactory;
 /**
  * @covers Wikibase\InternalSerialization\DeserializerFactory
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Bene* < benestar.wikimedia@gmail.com >
  */

--- a/tests/integration/Deserializers/EntityDeserializerTest.php
+++ b/tests/integration/Deserializers/EntityDeserializerTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\ItemId;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\EntityDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/integration/Deserializers/StatementDeserializerTest.php
+++ b/tests/integration/Deserializers/StatementDeserializerTest.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Statement\Statement;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\StatementDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class StatementDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/integration/LegacyDeserializerFactoryTest.php
+++ b/tests/integration/LegacyDeserializerFactoryTest.php
@@ -9,7 +9,7 @@ use Wikibase\InternalSerialization\LegacyDeserializerFactory;
 /**
  * @covers Wikibase\InternalSerialization\LegacyDeserializerFactory
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacyDeserializerFactoryTest extends \PHPUnit_Framework_TestCase {

--- a/tests/integration/RealEntitiesTest.php
+++ b/tests/integration/RealEntitiesTest.php
@@ -12,7 +12,7 @@ use Wikibase\DataModel\Entity\Property;
 /**
  * @covers Wikibase\InternalSerialization\DeserializerFactory
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class RealEntitiesTest extends \PHPUnit_Framework_TestCase {

--- a/tests/integration/SerializerFactoryTest.php
+++ b/tests/integration/SerializerFactoryTest.php
@@ -9,7 +9,7 @@ use Wikibase\InternalSerialization\SerializerFactory;
 /**
  * @covers Wikibase\InternalSerialization\SerializerFactory
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {

--- a/tests/integration/TestFactoryBuilder.php
+++ b/tests/integration/TestFactoryBuilder.php
@@ -13,7 +13,7 @@ use Wikibase\InternalSerialization\LegacyDeserializerFactory;
 use Wikibase\InternalSerialization\SerializerFactory;
 
 /**
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class TestFactoryBuilder {

--- a/tests/unit/Deserializers/EntityDeserializerTest.php
+++ b/tests/unit/Deserializers/EntityDeserializerTest.php
@@ -10,7 +10,7 @@ use Wikibase\InternalSerialization\Deserializers\EntityDeserializer;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\EntityDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class EntityDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Deserializers/LegacyEntityDeserializerTest.php
+++ b/tests/unit/Deserializers/LegacyEntityDeserializerTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\Property;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\LegacyEntityDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacyEntityDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Deserializers/LegacyEntityIdDeserializerTest.php
+++ b/tests/unit/Deserializers/LegacyEntityIdDeserializerTest.php
@@ -13,7 +13,7 @@ use Wikibase\InternalSerialization\Deserializers\LegacyEntityIdDeserializer;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\LegacyEntityIdDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacyEntityIdDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Deserializers/LegacyFingerprintDeserializerTest.php
+++ b/tests/unit/Deserializers/LegacyFingerprintDeserializerTest.php
@@ -14,7 +14,7 @@ use Wikibase\InternalSerialization\Deserializers\LegacyFingerprintDeserializer;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\LegacyFingerprintDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacyFingerprintDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Deserializers/LegacyItemDeserializerTest.php
+++ b/tests/unit/Deserializers/LegacyItemDeserializerTest.php
@@ -19,7 +19,7 @@ use Wikibase\InternalSerialization\Deserializers\LegacySnakListDeserializer;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\LegacyItemDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacyItemDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Deserializers/LegacyPropertyDeserializerTest.php
+++ b/tests/unit/Deserializers/LegacyPropertyDeserializerTest.php
@@ -14,7 +14,7 @@ use Wikibase\InternalSerialization\Deserializers\LegacyPropertyDeserializer;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\LegacyPropertyDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacyPropertyDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Deserializers/LegacySiteLinkListDeserializerTest.php
+++ b/tests/unit/Deserializers/LegacySiteLinkListDeserializerTest.php
@@ -12,7 +12,7 @@ use Wikibase\InternalSerialization\Deserializers\LegacySiteLinkListDeserializer;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\LegacySiteLinkListDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacySiteLinkListDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Deserializers/LegacySnakDeserializerTest.php
+++ b/tests/unit/Deserializers/LegacySnakDeserializerTest.php
@@ -16,7 +16,7 @@ use Wikibase\InternalSerialization\Deserializers\LegacySnakDeserializer;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\LegacySnakDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacySnakDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Deserializers/LegacySnakListDeserializerTest.php
+++ b/tests/unit/Deserializers/LegacySnakListDeserializerTest.php
@@ -13,7 +13,7 @@ use Wikibase\InternalSerialization\Deserializers\LegacySnakListDeserializer;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\LegacySnakListDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class LegacySnakListDeserializerTest extends \PHPUnit_Framework_TestCase {

--- a/tests/unit/Deserializers/LegacyStatementDeserializerTest.php
+++ b/tests/unit/Deserializers/LegacyStatementDeserializerTest.php
@@ -16,7 +16,7 @@ use Wikibase\InternalSerialization\Deserializers\LegacySnakListDeserializer;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\LegacyStatementDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Katie Filbert < aude.wiki@gmail.com >
  */

--- a/tests/unit/Deserializers/StatementDeserializerTest.php
+++ b/tests/unit/Deserializers/StatementDeserializerTest.php
@@ -11,7 +11,7 @@ use Wikibase\InternalSerialization\Deserializers\StatementDeserializer;
 /**
  * @covers Wikibase\InternalSerialization\Deserializers\StatementDeserializer
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class StatementDeserializerTest extends PHPUnit_Framework_TestCase {


### PR DESCRIPTION
The only change is an update to all `@license` tags, to match the new SPDX version.

I'm disabling another rule that runs into one issue in this codebase, because I found it not easy to fix. I suggest to try to reduce the number of exceptions in .phpcs.xml in later patches, if you think it's worth it.